### PR TITLE
Fix Swift package macOS requirement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "Tribute",
+    platforms: [.macOS(.v10_13)],
     products: [
         .executable(name: "tribute", targets: ["Tribute"]),
     ],


### PR DESCRIPTION
Sets 10.13 as the minimum macOS requirement in Package.swift
Fixes the error: `'sortedKeys' is only available in macOS 10.13 or newer`