### PR TITLE
Fix build error in unit tests

### DIFF
--- a/Sources/Tribute.swift
+++ b/Sources/Tribute.swift
@@ -201,7 +201,8 @@ class Tribute {
     }
 
     func fetchLibraries(in directory: URL, excluding: [Glob],
-                        includingPackages: Bool = true) throws -> [Library] {
+                        includingPackages: Bool = true) throws -> [Library]
+    {
         let manager = FileManager.default
         guard let enumerator = manager.enumerator(
             at: directory,
@@ -217,20 +218,25 @@ class Tribute {
             if excluding.contains(where: { $0.matches(licenceFile.path) }) {
                 continue
             }
-            let licensePath = String(licenceFile.standardized.path .dropFirst(directory.standardized.path.count))
+            let licensePath = String(licenceFile.standardized.path.dropFirst(directory.standardized.path.count))
             if includingPackages {
                 if licenceFile.lastPathComponent == "Package.resolved" {
                     libraries += try fetchLibraries(forResolvedPackageAt: licenceFile)
                     continue
                 }
                 if licenceFile.lastPathComponent == "Package.swift",
-                   !manager.fileExists(atPath: licenceFile.deletingPathExtension()
-                                        .appendingPathExtension("resolved").path) {
+                   !manager.fileExists(
+                       atPath: licenceFile.deletingPathExtension()
+                           .appendingPathExtension("resolved").path
+                   )
+                {
                     guard let string = try? String(contentsOf: licenceFile) else {
                         throw TributeError("Unable to read Package.swift at \(licensePath).")
                     }
                     if string.range(of: ".package(") != nil {
-                        throw TributeError("Found unresolved Package.swift at \(licensePath). Run 'swift package resolve' to resolve dependencies.")
+                        throw TributeError(
+                            "Found unresolved Package.swift at \(licensePath). Run 'swift package resolve' to resolve dependencies."
+                        )
                     }
                 }
             }
@@ -241,7 +247,8 @@ class Tribute {
             let ext = licenceFile.pathExtension
             let fileName = licenceFile.deletingPathExtension().lastPathComponent.lowercased()
             guard ["license", "licence"].contains(fileName),
-                  ["", "text", "txt", "md"].contains(ext) else {
+                  ["", "text", "txt", "md"].contains(ext)
+            else {
                 continue
             }
             var isDirectory: ObjCBool = false
@@ -283,19 +290,25 @@ class Tribute {
             let data = try Data(contentsOf: url)
             let resolved = try JSONDecoder().decode(Resolved.self, from: data)
             filter = Set(resolved.object.pins.flatMap {
-                [$0.package.lowercased(),
-                 $0.repositoryURL.deletingPathExtension().lastPathComponent.lowercased()]
+                [
+                    $0.package.lowercased(),
+                    $0.repositoryURL.deletingPathExtension().lastPathComponent.lowercased(),
+                ]
             })
         } catch {
             throw TributeError("Unable to read Swift Package file at \(url.path).")
         }
         guard let derivedDataDirectory = FileManager.default
-                .urls(for: .libraryDirectory, in: .userDomainMask).first?
-                .appendingPathComponent("Developer/Xcode/DerivedData") else {
+            .urls(for: .libraryDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("Developer/Xcode/DerivedData")
+        else {
             throw TributeError("Unable to locate ~/Library/Developer/Xcode/DerivedData directory.")
         }
-        let libraries = try fetchLibraries(in: derivedDataDirectory, excluding: [],
-                                           includingPackages: false)
+        let libraries = try fetchLibraries(
+            in: derivedDataDirectory,
+            excluding: [],
+            includingPackages: false
+        )
         return libraries.filter { filter.contains($0.name.lowercased()) }
     }
 

--- a/Tests/TemplateTests.swift
+++ b/Tests/TemplateTests.swift
@@ -14,7 +14,7 @@ class TemplateTests: XCTestCase {
         let template = Template(rawValue: "foo$namebaz")
         let library = Library(
             name: "bar",
-            licenceFile: URL(fileURLWithPath: ""),
+            licensePath: "",
             licenseType: .mit,
             licenseText: ""
         )
@@ -25,7 +25,7 @@ class TemplateTests: XCTestCase {
         let template = Template(rawValue: "foo$typebaz")
         let library = Library(
             name: "bar",
-            licenceFile: URL(fileURLWithPath: ""),
+            licensePath: "",
             licenseType: .mit,
             licenseText: ""
         )
@@ -36,7 +36,7 @@ class TemplateTests: XCTestCase {
         let template = Template(rawValue: "foo$textbaz")
         let library = Library(
             name: "quux",
-            licenceFile: URL(fileURLWithPath: ""),
+            licensePath: "",
             licenseType: .mit,
             licenseText: "bar"
         )
@@ -53,7 +53,7 @@ class TemplateTests: XCTestCase {
         """)
         let library = Library(
             name: "quux",
-            licenceFile: URL(fileURLWithPath: ""),
+            licensePath: "",
             licenseType: .mit,
             licenseText: "bar"
         )
@@ -71,7 +71,7 @@ class TemplateTests: XCTestCase {
         """)
         let library = Library(
             name: "quux",
-            licenceFile: URL(fileURLWithPath: ""),
+            licensePath: "",
             licenseType: .mit,
             licenseText: "bar"
         )
@@ -90,7 +90,7 @@ class TemplateTests: XCTestCase {
         """)
         let library = Library(
             name: "quux",
-            licenceFile: URL(fileURLWithPath: ""),
+            licensePath: "",
             licenseType: .mit,
             licenseText: "bar"
         )
@@ -113,7 +113,7 @@ class TemplateTests: XCTestCase {
         """)
         let library = Library(
             name: "Foobar 3.0",
-            licenceFile: URL(fileURLWithPath: ""),
+            licensePath: "",
             licenseType: .mit,
             licenseText: """
             line 1
@@ -134,7 +134,7 @@ class TemplateTests: XCTestCase {
         """)
         let library = Library(
             name: "Foobar 3.0",
-            licenceFile: URL(fileURLWithPath: ""),
+            licensePath: "",
             licenseType: .mit,
             licenseText: ""
         )
@@ -152,7 +152,7 @@ class TemplateTests: XCTestCase {
         """)
         let library = Library(
             name: "foo & bar - \"the best!\"",
-            licenceFile: URL(fileURLWithPath: ""),
+            licensePath: "",
             licenseType: .mit,
             licenseText: """
             line 1

--- a/Tribute.xcodeproj/project.pbxproj
+++ b/Tribute.xcodeproj/project.pbxproj
@@ -381,7 +381,6 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 3TFBFFT327;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -399,7 +398,6 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 3TFBFFT327;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Fixes build errors in `TemplateTest.swift` since `licenceFile:` was renamed `licencePath:`

Changes in `Tribute.swift` were made by the SwiftFormat run script phase