### PR TITLE
Add `$path` and `$url` support in templates

### DIFF
--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -55,6 +55,8 @@ struct Template: RawRepresentable {
                     <version>$version</version>
                     <type>$type</type>
                     <text>$text</text>
+                    <path>$path</path>
+                    <url>$url</url>
                 </license>$separator
                 $end
             </licenses>
@@ -75,6 +77,10 @@ struct Template: RawRepresentable {
                     <string>$type</string>
                     <key>text</key>
                     <string>$text</string>
+                    <key>path</key>
+                    <string>$path</string>
+                    <key>url</key>
+                    <string>$url</string>
                 </dict>$separator
                 $end
             </array>
@@ -87,7 +93,9 @@ struct Template: RawRepresentable {
                     "name": "$name",
                     "version": "$version",
                     "type": "$type",
-                    "text": "$text"
+                    "text": "$text",
+                    "path": "$path",
+                    "url": "$url"
                 }$separator,
                 $end
             ]
@@ -123,6 +131,7 @@ struct Template: RawRepresentable {
         let body = libraries.map { library -> String in
             let licenseType = library.licenseType?.rawValue ?? "Unknown"
             let version = library.version ?? "Unknown"
+            let url = library.url?.absoluteString ?? "Unknown"
             return section
                 .replacingOccurrences(
                     of: "$name", with: escape(library.name, as: format)
@@ -145,6 +154,12 @@ struct Template: RawRepresentable {
                 )
                 .replacingOccurrences(
                     of: "$text", with: escape(library.licenseText, as: format)
+                )
+                .replacingOccurrences(
+                    of: "$path", with: escape(library.licensePath, as: format)
+                )
+                .replacingOccurrences(
+                    of: "$url", with: escape(url, as: format)
                 )
         }.joined(separator: separator)
 

--- a/Sources/Tribute.swift
+++ b/Sources/Tribute.swift
@@ -109,6 +109,7 @@ enum LicenseType: String, CaseIterable {
 struct Library {
     var name: String
     var version: String?
+    var url: URL?
     var licensePath: String
     var licenseType: LicenseType?
     var licenseText: String
@@ -276,6 +277,7 @@ class Tribute {
                 let library = Library(
                     name: name,
                     version: nil,
+                    url: nil,
                     licensePath: String(licensePath),
                     licenseType: LicenseType(licenseText: licenseText),
                     licenseText: licenseText
@@ -381,7 +383,10 @@ class Tribute {
             guard let pin = resolved.pin(for: $0.name) else {
                 return nil
             }
-            return $0.with { $0.version = pin.state?.version }
+            return $0.with {
+                $0.url = pin.location
+                $0.version = pin.state?.version
+            }
         }
     }
 

--- a/Tests/TemplateTests.swift
+++ b/Tests/TemplateTests.swift
@@ -109,12 +109,15 @@ class TemplateTests: XCTestCase {
         {
             "name": "$name",
             "version": "$version",
-            "text": "$text"
+            "text": "$text",
+            "path": "$path",
+            "url": "$url"
         }
         """)
         let library = Library(
             name: "Foobar",
             version: "1.0.1",
+            url: .init(string: "https://github.com/example/Foobar")!,
             licensePath: "",
             licenseType: .mit,
             licenseText: """
@@ -126,7 +129,9 @@ class TemplateTests: XCTestCase {
         {
             "name": "Foobar",
             "version": "1.0.1",
-            "text": "line 1\\nline 2"
+            "text": "line 1\\nline 2",
+            "path": "",
+            "url": "https://github.com/example/Foobar"
         }
         """)
     }
@@ -136,10 +141,13 @@ class TemplateTests: XCTestCase {
         <root>
             <name>$name</name>
             <text>$text</text>
+            <path>$path</path>
+            <url>$url</url>
         </root>
         """)
         let library = Library(
             name: "foo & bar - \"the best!\"",
+            url: .init(string: "https://github.com/example/Foobar")!,
             licensePath: "",
             licenseType: .mit,
             licenseText: """
@@ -151,6 +159,8 @@ class TemplateTests: XCTestCase {
         <root>
             <name>foo &amp; bar - &quot;the best!&quot;</name>
             <text>line 1\nline 2</text>
+            <path></path>
+            <url>https://github.com/example/Foobar</url>
         </root>
         """)
     }


### PR DESCRIPTION
Hi Nick! Thank you for building this tool, it was really useful 😄

Besides the other info, I found I needed the license path/url and it seemed like an easy add to the tool. Two things:
  - I'm not too sure on the naming of the properties. Maybe you have an opinion on that.
  - I added both properties by default to xml, plist, and json exporting. I'm not sure if this should be the default, but since it shouldn't break any existing code that uses these files... (I think?)

Let me know if anything seems out of place to you!